### PR TITLE
Fix libveldrid-spirv.dylib not working on macOS 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
             build_args: release linux-x64
             build_target: linux-x64
             artifact_name: build/Release/linux-x64/libveldrid-spirv.so
-          - os: macos-latest
+          - os: macos-11
             build_args: release osx 'arm64;x86_64'
             build_target: osx
             artifact_name: build/Release/osx/libveldrid-spirv.dylib


### PR DESCRIPTION
- Fixes https://github.com/ppy/osu/issues/23164 (at least for OP)

See https://github.com/ppy/osu/issues/23164#issuecomment-1537204092. As listed on the readme, 10.15 is still the aim but I can't really fix/test that on my M1. As the next release is imminent, I would at least want to fix macOS 11 users on supported hardware.