### PR TITLE
Fix index out of range with version replace

### DIFF
--- a/src/libveldrid-spirv/libveldrid-spirv.cpp
+++ b/src/libveldrid-spirv/libveldrid-spirv.cpp
@@ -442,12 +442,18 @@ CompilationResult *CompileVertexFragment(const CrossCompileInfo &info)
     if (info.Target == GLSL && usesStorageResource)
     {
         std::string key = "#version 330";
-        vsText.replace(vsText.find(key), key.length(), "#version 430");
+        std::size_t idx = vsText.find(key);
+
+        if (idx != std::string::npos)
+            vsText.replace(idx, key.length(), "#version 430");
     }
     else if (info.Target == ESSL && usesStorageResource)
     {
         std::string key = "#version 300";
-        vsText.replace(vsText.find(key), key.length(), "#version 310");
+        std::size_t idx = vsText.find(key);
+
+        if (idx != std::string::npos)
+            vsText.replace(idx, key.length(), "#version 310");
     }
 
     std::string fsText = fsCompiler->compile();
@@ -456,12 +462,18 @@ CompilationResult *CompileVertexFragment(const CrossCompileInfo &info)
     if (info.Target == GLSL && usesStorageResource)
     {
         std::string key = "#version 330";
-        fsText.replace(vsText.find(key), key.length(), "#version 430");
+        std::size_t idx = fsText.find(key);
+
+        if (idx != std::string::npos)
+            fsText.replace(idx, key.length(), "#version 430");
     }
     else if (info.Target == ESSL && usesStorageResource)
     {
         std::string key = "#version 300";
-        fsText.replace(vsText.find(key), key.length(), "#version 310");
+        std::size_t idx = fsText.find(key);
+
+        if (idx != std::string::npos)
+            fsText.replace(idx, key.length(), "#version 310");
     }
 
     CompilationResult *result = new CompilationResult();


### PR DESCRIPTION
I will need to investigate this further, but it appears that once certain operations are performed the cross-compiler already emits `#version 430`.