### PR TITLE
Remove myget nuget stream

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="myget mellinoe" value="https://www.myget.org/F/mellinoe/api/v3/index.json" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
As of the writing of this PR, https://myget.org is currently down. This causes build failures.

I don't want to deal with unnecessary things (potentially) taking down entire CI pipelines like this did for me, so I'm pre-emptively removing this for the future.

This doesn't actually appear to be used.