### PR TITLE
Assign argument buffer indices from decorations

### DIFF
--- a/src/libveldrid-spirv/libveldrid-spirv.cpp
+++ b/src/libveldrid-spirv/libveldrid-spirv.cpp
@@ -223,6 +223,7 @@ Compiler *GetCompiler(std::vector<uint32_t> spirvBytes, const CrossCompileInfo &
     {
         auto ret = new CompilerMSL(spirvBytes);
         CompilerMSL::Options opts = {};
+        opts.enable_decoration_binding = true;
         ret->set_msl_options(opts);
         CompilerGLSL::Options commonOpts;
         commonOpts.vertex.flip_vert_y = info.InvertY;


### PR DESCRIPTION
Aiming to resolve https://github.com/ppy/osu-framework/issues/5719 once and for all (though I won't call it "resolved" for the time being, read more below).

This is immediately targeted to fix the triangles (`TriangleBorder` shader) issue after the masking SSBO changes.

Basically, this passes the [`--msl-decoration-binding`](https://manpages.ubuntu.com/manpages/jammy/man1/spirv-cross.1.html) option, which is documented as:
```
Use  SPIR-V  bindings  directly as MSL bindings.  This does not work in the general
case as there is no descriptor set support, and combined image samplers  are  split
up.   However,  if the shader author knows of binding limitations, this option will
avoid the need for reflection on Metal side.
```

Essentially, this means that if the GLSL shader defines 3 uniforms at sets `0`, `1`, `2`, but set `1` isn't used, set `2` is preserved for the resource that would logically appear after `1`. Compare the entry point definitions for (`Texture2D/TriangleBorder`):

Before:
```
vertex main0_out main0(main0_in in [[stage_in]], const device g_MaskingBuffer& MaskingBuffer [[buffer(0)]], constant g_GlobalUniforms& v_153 [[buffer(1)]])

fragment main0_out main0(main0_in in [[stage_in]], const device g_MaskingBuffer& MaskingBuffer [[buffer(0)]], constant m_BorderData& _671 [[buffer(1)]])
```

After:
```
vertex main0_out main0(main0_in in [[stage_in]], const device g_MaskingBuffer& MaskingBuffer [[buffer(0)]], constant g_GlobalUniforms& v_153 [[buffer(1)]])

fragment main0_out main0(main0_in in [[stage_in]], const device g_MaskingBuffer& MaskingBuffer [[buffer(0)]], constant m_BorderData& _671 [[buffer(2)]])
```

Note how after this change, `m_BorderData` in the fragment shader entry point is assigned the binding `2`. This is because `g_GlobalUniforms` exists at binding 1 but is unused and therefore trimmed from the cross-compiled result.

As for the limitations blurb at the end of the documentation saying this doesn't work for the general case - I don't think this is particularly relevant at this point. It could potentially become an issue with samplers which would reach the same issues as we're currently reaching with UBOs. Which brings me to my final point:

> though I won't call it "resolved" for the time being

I'm not going to call this fixed, because there's another interesting flag in the documentation: `--msl-force-active-argument-buffer-resources`. Though this may not be relevant to textures and samplers (so may not help with the above limitation), it sounds relevant to UBOs/SSBOs.  
However, I'm unable to get this flag to work right now.