### PR TITLE
Specify bundle version and short version string for iOS veldrid-spirv libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,8 @@ if(IOS)
 endif()
 
 set_target_properties(veldrid-spirv PROPERTIES MACOSX_FRAMEWORK_IDENTIFIER "sh.ppy.veldrid-spirv")
+set_target_properties(veldrid-spirv PROPERTIES MACOSX_FRAMEWORK_BUNDLE_VERSION "1.0.15")
+set_target_properties(veldrid-spirv PROPERTIES MACOSX_FRAMEWORK_SHORT_VERSION_STRING "1.0.15")
 
 set_target_properties(veldrid-spirv PROPERTIES PREFIX "lib")
 set_target_properties(veldrid-spirv PROPERTIES DEBUG_POSTFIX "")


### PR DESCRIPTION
Required for iOS app deployment.