### PR TITLE
Add arm64 simulator target to iOS builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: CI
 on:
+  workflow_dispatch:
   create: # when tags are created
   push:
     branches: [ master ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '2.7.18'
+
       - name: Get Submodules
         run: git submodule update --init --recursive
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
             build_args: release linux-x64
             build_target: linux-x64
             artifact_name: build/Release/linux-x64/libveldrid-spirv.so
-          - os: macos-11
+          - os: macos-latest
             build_args: release osx 'arm64;x86_64'
             build_target: osx
             artifact_name: build/Release/osx/libveldrid-spirv.dylib

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,10 +50,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '2.7.18'
-
       - name: Get Submodules
         run: git submodule update --init --recursive
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ jobs:
   native_builds:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: windows-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required (VERSION 3.0)
+cmake_policy(SET CMP0057 NEW)
 
 if(IOS)
     include(ios/ios.toolchain.cmake)

--- a/build-native.cmd
+++ b/build-native.cmd
@@ -7,7 +7,7 @@ set _CMAKE_GENERATOR_PLATFORM=x64
 set _NDK_DIR=
 set _ANDROID_ABI=arm64-v8a
 set _OS_DIR=
-set _ANDROID_PLATFORM=android-16
+set _ANDROID_PLATFORM=android-21
 
 :ArgLoop
 if [%1] == [] goto LocateVS

--- a/build-native.sh
+++ b/build-native.sh
@@ -34,7 +34,7 @@ while :; do
         ios)
             _CMakeEnableBitcode=-DENABLE_BITCODE=0
             _CMakeBuildTarget=veldrid-spirv
-            _CMakeGenerator="-G Xcode -T buildsystem=1"
+            _CMakeGenerator="-G Xcode"
             _CMakeExtraBuildArgs="--config Release"
             _OSDir=ios
             ;;

--- a/ext/sync-shaderc.cmd
+++ b/ext/sync-shaderc.cmd
@@ -2,3 +2,16 @@
 @echo off
 
 python %~dp0update_shaderc_sources.py --dir %~dp0shaderc --file %~dp0known_good.json
+
+:: Android NDK 27+ need this policy set on shaderc (as well as other tools)
+move /y %~dp0shaderc\CMakeLists.txt %~dp0shaderc\CMakeLists.tmp
+
+setlocal enableDelayedExpansion
+set p=
+for /f "tokens=* delims=" %%a in (%~dp0shaderc\CMakeLists.tmp) do (
+  if "!p!"=="cmake_minimum_required(VERSION 2.8.12)" echo cmake_policy(SET CMP0057 NEW^)>>%~dp0shaderc\CMakeLists.txt
+  (echo %%a) >>%~dp0shaderc\CMakeLists.txt
+  set p=%%a
+)
+del %~dp0shaderc\CMakeLists.tmp
+

--- a/ext/update_shaderc_sources.py
+++ b/ext/update_shaderc_sources.py
@@ -32,7 +32,7 @@ def command_output(cmd, directory, fail_ok=False):
     Raises a RuntimeError if the command fails to launch or otherwise fails.
     """
     if VERBOSE:
-        print('In {d}: {cmd}'.format(d=directory, cmd=cmd))
+        print(('In {d}: {cmd}'.format(d=directory, cmd=cmd)))
     p = subprocess.Popen(cmd,
                          cwd=directory,
                          stdout=subprocess.PIPE)
@@ -100,12 +100,12 @@ def main():
     args = parser.parse_args()
     commits = GetGoodCommits(args.known_good_file)
     distutils.dir_util.mkpath(args.dir)
-    print('Change directory to {d}'.format(d=args.dir))
+    print(('Change directory to {d}'.format(d=args.dir)))
     os.chdir(args.dir)
     # Create the subdirectories in sorted order so that parent git repositories
     # are created first.
     for c in sorted(commits, key=attrgetter('subdir')):
-        print('Get {n}\n'.format(n=c.name))
+        print(('Get {n}\n'.format(n=c.name)))
         c.Checkout()
     sys.exit(0)
 if __name__ == '__main__':

--- a/ext/update_shaderc_sources.py
+++ b/ext/update_shaderc_sources.py
@@ -17,7 +17,7 @@ repositories."""
 from operator import attrgetter
 import argparse
 import json
-import distutils.dir_util
+import pathlib
 import os.path
 import subprocess
 import sys
@@ -75,7 +75,7 @@ class GoodCommit(object):
                                      self.commit + '^{commit}'],
                                     cwd=self.subdir)
     def Clone(self):
-        distutils.dir_util.mkpath(self.subdir)
+        pathlib.Path(self.subdir).mkdir(parents=True, exist_ok=True)
         command_output(['git', 'clone', self.GetUrl(), '.'], self.subdir)
     def Fetch(self):
         command_output(['git', 'fetch', 'known-good'], self.subdir)
@@ -99,7 +99,7 @@ def main():
                         help="The file containing known-good commits. Default is \'' + KNOWN_GOOD_FILE + '\'.")
     args = parser.parse_args()
     commits = GetGoodCommits(args.known_good_file)
-    distutils.dir_util.mkpath(args.dir)
+    pathlib.Path(args.dir).mkdir(parents=True, exist_ok=True)
     print(('Change directory to {d}'.format(d=args.dir)))
     os.chdir(args.dir)
     # Create the subdirectories in sorted order so that parent git repositories


### PR DESCRIPTION
Required to support builiding our iOS projects with the `iossimulator-arm64` target, supposedly avoiding Rosetta emulation and also allowing us to remove the existing `iPhone`/`iPhoneSimulator` platform configurations thanks to JetBrains Rider's latest updates.

Script tested locally on my machine with Xcode 15.4 / iOS 17.5 SDK.

Expected output:

![CleanShot 2024-08-08 at 12 04 01](https://github.com/user-attachments/assets/280e455d-ae2e-40e4-94ed-e5337ff3080d)
