### PR TITLE
Build for older OSX version to support x86_64 platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required (VERSION 3.0)
 cmake_policy(SET CMP0057 NEW)
 
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment version")
+
 if(IOS)
     include(ios/ios.toolchain.cmake)
 endif()


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/29719 (along with new o!f and osu! builds)

With the latest batch of changes in https://github.com/ppy/veldrid-spirv/pull/8, we updated the GitHub runner which now builds targeting macOS 14. This broke x86_64 platforms which are locked to an older OS.