### PR TITLE
Remove `ppy.Veldrid` reference

### DIFF
--- a/src/Veldrid.SPIRV/Veldrid.SPIRV.csproj
+++ b/src/Veldrid.SPIRV/Veldrid.SPIRV.csproj
@@ -15,7 +15,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="ppy.Veldrid" Version="4.9.69-ga405fe8484"/>
         <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.255">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
Unused. Makes this package just contain the glsl + spirv-cross compilers.